### PR TITLE
readd fix yes yes

### DIFF
--- a/Rating_Algorithm.py
+++ b/Rating_Algorithm.py
@@ -192,7 +192,7 @@ def findSongFolder(song_id):
     song_options = os.listdir(bsPath)
     songFound = False
     for song in song_options:
-        if song.find(song_id) != -1:
+        if song.startswith(song_id+" ") != False:
             songFolder = song
             songFound = True
             break

--- a/Rating_Algorithm.py
+++ b/Rating_Algorithm.py
@@ -192,7 +192,7 @@ def findSongFolder(song_id):
     song_options = os.listdir(bsPath)
     songFound = False
     for song in song_options:
-        if song.startswith(song_id+" ") != False:
+        if song.startswith(song_id+" "):
             songFolder = song
             songFound = True
             break


### PR DESCRIPTION
Currently with the way the .find() is set up, when for example searching for song ID 9ee it instead finds the song with the ID of 19ee4 because this also fits what find it looking for and thus selects the wrong song.

With startswith() and a space concatenated to the end of the search it makes sure it will only find the exact song ID you input